### PR TITLE
added the ostruct gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "devise"
 gem "font-awesome-sass", "~> 6.1"
 gem "simple_form", github: "heartcombo/simple_form"
 gem "sassc-rails"
+gem "ostruct"
 
 group :development, :test do
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,7 @@ GEM
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    ostruct (0.6.1)
     pg (1.5.9)
     popper_js (2.11.8)
     psych (5.2.0)
@@ -325,6 +326,7 @@ DEPENDENCIES
   font-awesome-sass (~> 6.1)
   importmap-rails
   jbuilder
+  ostruct
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)


### PR DESCRIPTION
Added the gem to avoid this annoying error message that shows up on every `rails` command

```
➜  rails-authentication-1808 git:(main) rails db:create db:migrate db:seed
/Users/dougberks/.rbenv/versions/3.3.5/lib/ruby/3.3.0/json/generic_object.rb:2: warning: /Users/dougberks/.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```